### PR TITLE
Improved name of field variables in MapAttachment

### DIFF
--- a/src/talk/chat/attachment/chat-attachment.ts
+++ b/src/talk/chat/attachment/chat-attachment.ts
@@ -383,8 +383,8 @@ export class MapAttachment implements ChatAttachment {
     constructor(
         public Lat: number = 0,
         public Lng: number = 0,
-        public Name: string = '',
-        public C: boolean = false
+        public Address: string = '',
+        public IsCurrent: boolean = false
     ) {
 
     }
@@ -396,9 +396,9 @@ export class MapAttachment implements ChatAttachment {
     readAttachment(rawData: any): void {
         this.Lat = rawData['lat'];
         this.Lng = rawData['lng'];
-        this.Name = rawData['a'];
+        this.Address = rawData['a'];
 
-        this.C = rawData['c'];
+        this.IsCurrent = rawData['c'];
     }
 
     toJsonAttachment() {


### PR DESCRIPTION
`a`는 `address`를 의미하며, `c`는 `isCurrent`를 의미합니다.