### PR TITLE
export managed-chat-channel, managed-chat-user, managed-open-link

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,10 @@ export * from './talk/struct/auth/login-access-data-struct';
 export * from './talk/struct/channel-board-meta-struct';
 export * from './talk/struct/api/account/client-settings-struct';
 
+export * from './talk/managed/managed-chat-channel';
+export * from './talk/managed/managed-chat-user';
+export * from './talk/managed/managed-open-link';
+
 export * from './api/service-client';
 
 export * from './oauth/access-data-provider';


### PR DESCRIPTION
현재 /talk/managed에 존재하는 class들이 export 되고 있지 않습니다.