### PR TITLE
Add generateAutoLoginToken

### DIFF
--- a/src/api/auth-client.ts
+++ b/src/api/auth-client.ts
@@ -231,8 +231,7 @@ export class AuthClient extends WebApiClient implements AccessDataProvider {
 	
 	generateAutoLoginToken(): string {
         if (!this.accessData) throw new Error('Not logon');
-		console.log(this.accessData);
-		let res = `PITT|${this.accessData.autoLoginEmail}|${this.accessData.refreshToken}|${this.deviceUUID}|INORAN`;
+	    let res = `PITT|${this.accessData.autoLoginEmail}|${this.accessData.refreshToken}|${this.deviceUUID}|INORAN`;
 
         let hash = crypto.createHash('sha512');
 

--- a/src/api/auth-client.ts
+++ b/src/api/auth-client.ts
@@ -228,6 +228,18 @@ export class AuthClient extends WebApiClient implements AccessDataProvider {
 
         return hash.digest('hex');
     }
+	
+	generateAutoLoginToken(): string {
+        if (!this.accessData) throw new Error('Not logon');
+		console.log(this.accessData);
+		let res = `PITT|${this.accessData.autoLoginEmail}|${this.accessData.refreshToken}|${this.deviceUUID}|INORAN`;
+
+        let hash = crypto.createHash('sha512');
+
+        hash.update(res);
+
+        return hash.digest('hex');
+	}
 
     logout() {
         this.currentLogin = null;


### PR DESCRIPTION
자동 로그인 토큰 만드는 메서드 추가하였습니다.

```PITT|메일(autologin_email)|refresh_token|uuid|INORAN```를 sha512(+hex)한 문자열이 비밀번호가 되며 `node-kakao`에서는 자동 로그인 비밀번호를 사용하려면 `loginToken` 함수를 사용하면 됩니다.

`autologin_email`과 `refresh_token` 모두 `login` API를 호출했을 때 반환받는 정보들입니다.

`refresh_token` 자리에 평문 비밀번호가 오는 경우도 있는 것으로 보이는데 이 경우 해당 토큰으로 로그인은 되지 않습니다.