### PR TITLE
Convert bodyBuffer to Buffer

### DIFF
--- a/src/network/loco-socket.ts
+++ b/src/network/loco-socket.ts
@@ -176,6 +176,10 @@ export abstract class LocoBasicSocket implements LocoSocket {
 
         let headerBuffer = this.createHeaderBuffer(header);
 
+        if (!Buffer.isBuffer(bodyBuffer)) {
+            bodyBuffer = Buffer.from(bodyBuffer);
+        }
+
         headerBuffer.copy(buffer, offset, 0);
         bodyBuffer.copy(buffer, offset + 22, 0);
         


### PR DESCRIPTION
Electron 환경에서 로그인 시 `Error: Booking failed. code: TypeError: argument should be a Buffer` 가 뜨던 문제를 해결하였습니다.