### PR TITLE
Fix update nickname

### DIFF
--- a/src/talk/managed/managed-chat-user.ts
+++ b/src/talk/managed/managed-chat-user.ts
@@ -87,7 +87,7 @@ export class ManagedChatUserInfo implements ChatUserInfo {
     }
 
     updateNickname(nickname: string) {
-        if (this.memberStruct.nickname !== nickname) {
+        if (nickname && this.memberStruct.nickname !== nickname) {
             this.memberStruct.nickname = nickname;
         }
     }


### PR DESCRIPTION
일반 채팅방에서 유저의 닉네임이 undefined로 인식되는 현상이 있습니다.
메세지 패킷의 구조가 바뀌어서 이러는 것 같은데요, 현재 오픈채팅의 메세지 패킷에는 authorNickname이 존재하지만 일반 채팅방에서는 authorNickname이 존재하지 않습니다.
onMessagePacket 내에서 매번 managedInfo.updateNickname을 호출하고 있는 상황인데 해당 값이 유효할 때만 update를 하게 할 필요가 있어 보입니다.