### PR TITLE
fix(oauth): type of OAuthCredential.userId

### DIFF
--- a/src/oauth/index.ts
+++ b/src/oauth/index.ts
@@ -7,25 +7,18 @@
 import { Long } from "bson";
 
 export interface OAuthCredential {
-
-  readonly userId: Long;
-
+  readonly userId: Pick<Long, "low" | "high" | "unsigned">;
   readonly deviceUUID: string;
-
   readonly accessToken: string;
   readonly refreshToken: string;
-
 }
 
 export interface OAuthInfo {
-
   /**
    * Token type
    */
   type: string;
-
   credential: OAuthCredential;
-
   /**
    * OAuth token expires (secs)
    */
@@ -36,7 +29,5 @@ export interface OAuthInfo {
  * Provides oauth credential data
  */
 export interface CredentialProvider {
-
   getCredential(): OAuthCredential;
-
 }


### PR DESCRIPTION
실제 응답을 받아보니 "low", "high", "unsigned" 만 존재했습니다.

"low", "high", "unsigned" 가 무조건 응답에 포함되는 것인지는 모르겠으나, 일단 기존의 type 이 optional 이 아니므로, 무조건 응답에 포함된다고 가정했습니다.  

만일 이 세 필드 이외에 다른 필드들은 경우에 따라 optional 하게 응답에 포함되는 것이라면 

```ts
export interface OAuthCredential {
  readonly userId: Partial<Long> & Pick<Long, "low" | "high" | "unsigned">;
 // ...
}
```

또는 

```ts
export interface OAuthCredential {
readonly userId: Required<Partial<Long>, "low" | "high" | "unsigned">;
 // ...
}
```

으로 하면 됩니다. (후자의 `Required` 의 경우, [built-in](https://www.typescriptlang.org/docs/handbook/utility-types.html#requiredtype) 이 아닌, [utility-types](https://github.com/piotrwitek/utility-types#requiredt-k) 의 type 입니다.)