### PR TITLE
style: newline configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.md]
+max_line_length = off

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
안녕하세요.

PR 을 날리려다 보니 파일마다 줄바꿈 문자가 다르더군요. 
예를 들면, 소스는 LF 인데, 설정파일은 CRLF 인 등..

(예: Linux 에서 tsconfig.json 를 수정하고 git diff) 

![Screenshot from 2021-06-30 12-32-59](https://user-images.githubusercontent.com/28584151/123897961-57bd8e00-d99f-11eb-8723-8d8be8f3fa9d.png)

New Line 문자는 Windows 에선 기본으로 CRLF, macOS 와 Linux 같은 Unix-like 시스템에서는 LF 를 사용하고 있습니다.
이종의 OS 를 사용하는 개발자들이 협업시, 관례적으로 LF 로 통일하는 것이 보편적입니다.

```shell
git config --global core.eol <option>
```

위와 같은 설정으로 개발자가 개인적으로 대응할 수도 있지만, 어디까지나 수동이며, global 설정이고, 모든 collaborator 에게 자동으로 일괄 적용되지 않습니다.

그래서 project 로 scope 를 좁혀 설정하기 위해 .gitattributes 를 도입했습니다. 

```
* text=auto eol=lf
```

이렇게 하면 모든 텍스트 파일에 대해, Windows 에서 working space 의 소스가 CRLF 더라도, commit 되면서 .git 디렉토리 내부에서는 LF로 바뀌게 됩니다. checkout 시(git checkout 이 아니라 pull, reset 등 모두 포함해 이력으로 working space 덮어쓰기를 의미)에는 다시 OS 의 설정에 맞게 바뀌게 됩니다.

여기에 더 나아가, .editorconfig 를 도입해 IDE 에서 working space 의 파일까지 LF 로 관리하게 했습니다. 이는, 어쩌다 간혹 있는, git 을 통하지 않는 파일의 공유에도 개발 생태계의 관례적 표준으로 대응하기 위해서입니다.

<small>_P.S. 참고로, .editorconfig 는 확장자를 구별하여 언어별로 다른 설정을 할 수도 있습니다. 다만 기존 linter(e.g. eslint), formatter(e.g. prettier) 와 역할이 부분적으로 겹칠 수는 있습니다. 하지만, .editorconfig 의 목적은 CLI 로서의 formatter 가 아니라, IDE 에 특정 library-specific 한 extension 등을 설치하지 않고도 표준적인 auto-fix 를 구현한다는 점에 있으니 역할이 사뭇 다른 측면도 있습니다. 이런 연유로 추가적인 설정은 하지 않았지만, 관심이 생기신다면 한번 살펴보실 만 하다고 생각합니다._</small>