### PR TITLE
feat(request): export interfaces

### DIFF
--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -81,14 +81,14 @@ export interface CommandResultFailed extends RootCommandResult {
 
 }
 
-interface CommandResultDoneValue<T> extends RootCommandResult {
+export interface CommandResultDoneValue<T> extends RootCommandResult {
 
   readonly success: true;
   readonly result: T;
 
 }
 
-interface CommandResultDoneVoid extends RootCommandResult {
+export interface CommandResultDoneVoid extends RootCommandResult {
 
   readonly success: true;
 


### PR DESCRIPTION
라이브러리를 소비하는 측에서 `CommandResultDoneValue` 와 `CommandResultDoneVoid` 등에 고루고루 접근 가능한 것이 필요할 수 있습니다.

아주 간단한 예시를 생각해보겠습니다.

```ts
export async function loginByEmailAndPassword(
  authApiClient: AuthApiClient
) {
  const res = await authApiClient.login({
    email: process.env.KAKAOTALK_ACCOUNT_EMAIL as string,
    password: process.env.KAKAOTALK_ACCOUNT_PASSWORD as string,
  });
  if (!res.success) {
    throw new Error(
      `Web login by email and password failed with status: ${res.status}`
    );
  }
  return res;
}
```

node-kakao 를 소비하는 쪽에서 다음과 같은 간단한 facade pattern 을 export 한다고 가정해보겠습니다.

tsc 의 `--declaration` 옵션이 켜져 있으면, 위 `loginByEmailAndPassword` 함수의 return type 역시 type declaration 에 포함되어야 합니다. 

만약 `AuthApiClient.login` 의 return 타입인 `AsyncCommandResult` (`AsyncCommandResult<LoginResult>`) 가 사용된다면, 문제가 없습니다. 이미 node-kakao 가 export 하기 때문입니다.

https://github.com/storycraft/node-kakao/blob/f5465d22da4e49652e6450a9b3201711c1938fcb/src/request/index.ts#L99 


그러나 컴파일러는 반환 타입의 `success` 필드가 반드시 true 로 보장되는 것을 추론할 수 있고, 따라서 `AsyncCommandResult` 대신 `CommandResultDoneValue` (`Promise<CommandResultDoneValue<LoginResult>>`) 로 추론합니다.

문제는 `CommandResultDoneValue` 는 export 되지 않아, tsc 가 접근할 수 없고, type declaration file 을 작성할 수 없다는 것입니다.

https://github.com/storycraft/node-kakao/blob/f5465d22da4e49652e6450a9b3201711c1938fcb/src/request/index.ts#L84-L89

실제 위 코드의 오류 메세지는 다음과 같습니다.

```
Return type of exported function has or is using name 'CommandResultDoneValue' 
from external module "/path/to/node_modules/node-kakao/dist/request/index" 
but cannot be named.ts(4058)
```

P.S. `RootCommandResult` 는 export 하지 않고 둔 이유는 extend 를 위한 base interface 역할만 하고, (`CommandResultDoneValue` 등과는 달리) 실제 node-kakao 가 반환가능한 특정 객체의 타입을 지칭하지 않아, 외부에서 사용할 여지가 없다고 생각했기 때문입니다.